### PR TITLE
Support passing arguments to programs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
         "./samples/panic/Cargo.toml",
         "./samples/hello/Cargo.toml",
         "./samples/fault/Cargo.toml",
-        "./samples/snake/Cargo.toml",
         "./Cargo.toml"
-    ]
+    ],
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Jonathan 'theJPster' Pallant <neotron@thejpster.org.uk>"]
 
 [dependencies]
 neotron-ffi = "0.1"
-neotron-api = "0.1"
+neotron-api = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 crossterm = "0.26"

--- a/samples/chello/chello.c
+++ b/samples/chello/chello.c
@@ -9,22 +9,11 @@
 
 const NeotronApi *g_api;
 
-static int main(void);
-
 /*
  * Called by Neotron OS when the binary is 'run'.
  */
-int app_entry(const NeotronApi *f) {
+int app_entry(const NeotronApi *f, size_t argc, const FfiString* argv) {
   g_api = f;
-  return main();
-}
-
-/*
- * Our main function.
- *
- * Just prints a message and exits.
- */
-static int main(void) {
   // allocate a buffer
   void *buffer = calloc(1024, 1);
   // write a string into it
@@ -33,6 +22,10 @@ static int main(void) {
   printf(buffer);
   // free the buffer
   free(buffer);
+  for(size_t i = 0; i < argc; i++) {
+    const FfiString* ffi_arg = &argv[i];
+    printf("Arg %u: %.*s\n", (unsigned int) i, ffi_arg->_0.data_len, ffi_arg->_0.data);   
+  }
   return 0;
 }
 


### PR DESCRIPTION
Uses the new entry function from Neotron API 0.2. Allows applications to ask "What was argument number 2?" and get an `Option<&'static str>`.